### PR TITLE
Added plugin descriptor for InSynth

### DIFF
--- a/features/ch.epfl.insynth.feature
+++ b/features/ch.epfl.insynth.feature
@@ -3,10 +3,14 @@ plugin-descriptor {
   documentation = "https://github.com/kaptoxic/scala-ide-insynth-integration/wiki"
   issue-tracker = "https://github.com/kaptoxic/scala-ide-insynth-integration/issues"
   update-sites = [
-  	"http://lara.epfl.ch/~insynth/indigo-2_9" ,
-  	"http://lara.epfl.ch/~insynth/indigo-2_10" ,
-  	"http://lara.epfl.ch/~insynth/juno-2_9" ,
-  	"http://lara.epfl.ch/~insynth/juno-2_10"
+  	"http://lara.epfl.ch/~insynth/dev-indigo-2_9" ,
+  	"http://lara.epfl.ch/~insynth/dev-indigo-2_10" ,
+  	"http://lara.epfl.ch/~insynth/dev-juno-2_9" ,
+  	"http://lara.epfl.ch/~insynth/dev-juno-2_10" ,
+  	"http://lara.epfl.ch/~insynth/stable-indigo-2_9" ,
+  	"http://lara.epfl.ch/~insynth/stable-indigo-2_10" ,
+  	"http://lara.epfl.ch/~insynth/stable-juno-2_9" ,
+  	"http://lara.epfl.ch/~insynth/stable-juno-2_10"
 	]
   category = incubation
   website = "http://lara.epfl.ch/w/insynth"


### PR DESCRIPTION
InSynth currently has two update sites (for flavors Indigo \* { Scala 2.9, Scala 2.10 }).

Update sites are build with a [script](https://github.com/kaptoxic/scala-ide-insynth-integration/blob/changesForEcosystem/ch.epfl.insynth.build/ecosystem-build.sh) similar to ScalaTest but I am not sure whether they are built with the right parameters - builds pass but there are issues with the Scala compiler dependency when installing from the 2.10 flavor update site...
Perhaps falvors for Scala IDE and Scala are not configured correctly (in [pom](https://github.com/kaptoxic/scala-ide-insynth-integration/blob/changesForEcosystem/ch.epfl.insynth.build/pom.xml))
