### PR TITLE
Switches to new InSynth location

### DIFF
--- a/features/ch.epfl.insynth.feature
+++ b/features/ch.epfl.insynth.feature
@@ -3,14 +3,7 @@ plugin-descriptor {
   documentation = "https://github.com/kaptoxic/scala-ide-insynth-integration/wiki"
   issue-tracker = "https://github.com/kaptoxic/scala-ide-insynth-integration/issues"
   update-sites = [
-  	"http://lara.epfl.ch/~insynth/dev-indigo-2_9" ,
-  	"http://lara.epfl.ch/~insynth/dev-indigo-2_10" ,
-  	"http://lara.epfl.ch/~insynth/dev-juno-2_9" ,
-  	"http://lara.epfl.ch/~insynth/dev-juno-2_10" ,
-  	"http://lara.epfl.ch/~insynth/stable-indigo-2_9" ,
-  	"http://lara.epfl.ch/~insynth/stable-indigo-2_10" ,
-  	"http://lara.epfl.ch/~insynth/stable-juno-2_9" ,
-  	"http://lara.epfl.ch/~insynth/stable-juno-2_10"
+    "http://lara.epfl.ch/~insynth/combined"
 	]
   category = incubation
   website = "http://lara.epfl.ch/w/insynth"

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   <dependencies>
     <dependency>
       <groupId>org.scala-ide</groupId>
-      <artifactId>build-tools_2.9.2</artifactId>
-      <version>0.3.8</version>
+      <artifactId>build-tools_2.10</artifactId>
+      <version>0.4.0</version>
     </dependency>
   </dependencies>
   <profiles>
@@ -71,7 +71,7 @@
       <!-- extra repository containing the build package -->
       <id>typesafe-ide</id>
       <name>Typesafe IDE repository</name>
-      <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
+      <url>http://repo.typesafe.com/typesafe/ide-2.10</url>
       <snapshots><enabled>true</enabled></snapshots>
     </repository>
   </repositories>


### PR DESCRIPTION
I worked with @kaptoxic on updating the InSynth plugin build script. It now generates only one update site. The update site contains build compatible with the latest stable, and the latest RC.

Also updates to latest build-tools.
